### PR TITLE
chore: avoid Playwright deps on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "postinstall": "prisma generate && npx playwright install --with-deps",
+    "postinstall": "prisma generate && npx playwright install",
     "build": "prisma generate && next build --turbopack",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary
- remove Playwright system dependency installation from postinstall script

## Testing
- `npm run postinstall` *(fails: Download failed: server returned code 403)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6dcc3f4f4832ab33a31b1831cc867