### PR TITLE
feat: add OpenAI-backed query answering

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -38,7 +38,13 @@
       var res = await fetch(base + '/api/query', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ siteId: siteId, question: question }) });
       var data = await res.json();
       results.innerHTML='';
-      data.forEach(function(row){
+      if(data.answer){
+        var ans=document.createElement('div');
+        ans.textContent=data.answer;
+        ans.style.padding='8px 6px';
+        results.appendChild(ans);
+      }
+      (data.sources || []).forEach(function(row){
         var item=document.createElement('div'); item.style.padding='8px 6px'; item.style.borderTop='1px solid #eee';
         var a=document.createElement('a'); a.href=row.url; a.textContent=row.title || row.url; a.style.fontWeight='600'; a.style.display='block'; a.addEventListener('click', function(e){ e.preventDefault(); window.location=row.url; }); item.appendChild(a);
         if(row.snippet){ var p=document.createElement('div'); p.textContent=row.snippet; p.style.fontSize='12px'; p.style.color='#444'; item.appendChild(p); }

--- a/src/app/admin/AskSite.tsx
+++ b/src/app/admin/AskSite.tsx
@@ -2,12 +2,13 @@
 import { useState } from "react";
 
 export default function AskSite({ siteId }: { siteId: string }) {
-	const [question, setQuestion] = useState("");
-	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState<string | null>(null);
-	const [results, setResults] = useState<
-		Array<{ url: string; title?: string; snippet?: string; screenshotUrl?: string; confidence: number }>
-	>([]);
+        const [question, setQuestion] = useState("");
+        const [loading, setLoading] = useState(false);
+        const [error, setError] = useState<string | null>(null);
+        const [answer, setAnswer] = useState<string | null>(null);
+        const [results, setResults] = useState<
+                Array<{ url: string; title?: string; snippet?: string; screenshotUrl?: string; confidence: number }>
+        >([]);
 
 	async function onAsk(e: React.FormEvent) {
 		e.preventDefault();
@@ -25,8 +26,9 @@ export default function AskSite({ siteId }: { siteId: string }) {
 				try { const j = await res.json(); detail = j?.error || ""; } catch {}
 				throw new Error(`Query failed (${res.status})${detail ? `: ${detail}` : ""}`);
 			}
-			const data = await res.json();
-			setResults(data || []);
+                        const data = await res.json();
+                        setAnswer(data?.answer || null);
+                        setResults(data?.sources || []);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : "Something went wrong";
 			setError(message);
@@ -35,7 +37,7 @@ export default function AskSite({ siteId }: { siteId: string }) {
 		}
 	}
 
-	const top = results[0];
+        const top = results[0];
 
 	return (
 		<div className="mt-4 space-y-2">
@@ -51,10 +53,16 @@ export default function AskSite({ siteId }: { siteId: string }) {
 				</button>
 			</form>
 			{error && <div className="text-sm text-red-600">{error}</div>}
-			{top && (
-				<div className="border rounded p-3 bg-gray-50">
-					<div className="text-sm text-gray-500">Best match ({Math.round(top.confidence * 100)}%)</div>
-					<div className="font-medium">{top.title || top.url}</div>
+                        {answer && (
+                                <div className="border rounded p-3 bg-gray-50">
+                                        <div className="font-medium">Answer</div>
+                                        <p className="text-sm text-gray-700 mt-1 whitespace-pre-wrap">{answer}</p>
+                                </div>
+                        )}
+                        {top && (
+                                <div className="border rounded p-3 bg-gray-50">
+                                        <div className="text-sm text-gray-500">Best match ({Math.round(top.confidence * 100)}%)</div>
+                                        <div className="font-medium">{top.title || top.url}</div>
 					{top.snippet && <p className="text-sm text-gray-700 mt-1 whitespace-pre-wrap">{top.snippet}</p>}
 					<a className="text-white hover:underline text-sm mt-1 inline-block" href={top.url} target="_blank" rel="noreferrer">
 						Open page


### PR DESCRIPTION
## Summary
- add OpenAI-based answer synthesis to query API and return sources
- display generated answers in widget, admin AskSite, and graph pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6fa53ab9c832ab8663dc905ee450d